### PR TITLE
pc - update pom.xml to fix changing "example" to "rec" in path names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <java.version>21</java.version>
     <mainClass>edu.ucsb.cs156.rec.ExampleApplication</mainClass>
     <app.package>edu.ucsb.cs156.rec</app.package>
-    <app.packagePath>edu/ucsb/cs156/example</app.packagePath>
+    <app.packagePath>edu/ucsb/cs156/rec</app.packagePath>
     <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
     <!-- https://mvnrepository.com/artifact/com.github.eirslett/frontend-maven-plugin -->
     <frontend-maven-plugin.version>1.15.1</frontend-maven-plugin.version>
@@ -229,7 +229,7 @@
             <exclude>**/${app.packagePath}/services/CurrentUserServiceImpl.*</exclude>
             <exclude>**/${app.packagePath}/services/GrantedAuthoritiesService.*</exclude>
             <exclude>**/${app.packagePath}/ExampleApplication.*</exclude>
-            <exclude>**/edu/ucsb/cs156/example/services/wiremock/*</exclude>
+            <exclude>**/${app.packagePath}/services/wiremock/*</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
In this PR, we update pom.xml to fix changing "example" to "rec" in path names.

A couple of these were missed during the initial set up of the starter repo.

This fixes a problem with jacoco tests.

