### PR TITLE
pc - retry Github Actions that fail on Deploy step (writing to gh-pages branch)

### DIFF
--- a/.github/workflows/01-gh-pages-pr-table.yml
+++ b/.github/workflows/01-gh-pages-pr-table.yml
@@ -74,9 +74,15 @@ jobs:
         mkdir -p site
         cp -r frontend/docs-index/* site
   
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        folder: site # The folder the action should deploy.
-        branch: gh-pages
-        clean: false # Automatically remove deleted files from the deploy branch
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          folder: site # The folder the action should deploy.
+          branch: gh-pages
+          clean: false # Automatically remove deleted files from the deploy branch
+

--- a/.github/workflows/04-gh-pages-redeploy-part-2.yml
+++ b/.github/workflows/04-gh-pages-redeploy-part-2.yml
@@ -72,12 +72,17 @@ jobs:
         mkdir -p site
         cp -r frontend/docs-index/* site
         
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        folder: site # The folder the action should deploy.
-        branch: gh-pages
-        clean: true # Automatically remove deleted files from the deploy branch
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          folder: site # The folder the action should deploy.
+          branch: gh-pages
+          clean: true # Automatically remove deleted files from the deploy branch
 
   deploy-main-docs:
     name: Deploy Documentation for main branch

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -51,13 +51,18 @@ jobs:
         echo "prefix=${prefix}"
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
     
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/site/jacoco # The folder where mvn puts the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: ${{env.prefix}}jacoco # The folder that we serve our files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/site/jacoco # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: ${{env.prefix}}jacoco # The folder that we serve our files from
 
 
   

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -62,14 +62,18 @@ jobs:
           echo "prefix=${prefix}"
           echo "prefix=${prefix}" >> "$GITHUB_ENV"
       
-      - name: Deploy 🚀
+      - name: Deploy 🚀    
         if: always() # always upload artifacts, even if tests fail
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: Wandalen/wretry.action@master
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: frontend/coverage/lcov-report # The folder where the javadoc files are located
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: ${{env.prefix}}coverage # The folder that we serve our javadoc files from
+         action: JamesIves/github-pages-deploy-action@v4
+         attempt_limit: 3
+         attempt_delay: 5000
+         with: |
+            branch: gh-pages # The branch the action should deploy to.
+            folder: frontend/coverage/lcov-report # The folder where the javadoc files are located
+            clean: true # Automatically remove deleted files from the deploy branch
+            target-folder: ${{env.prefix}}coverage # The folder that we serve our javadoc files from
 
 
   

--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -87,11 +87,15 @@ jobs:
           echo "prefix=${prefix}"
           echo "prefix=${prefix}" >> "$GITHUB_ENV"
       
-      - name: Deploy 🚀
+      - name: Deploy 🚀    
         if: always() # always upload artifacts, even if tests fail
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: Wandalen/wretry.action@master
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: frontend/reports/mutation # The folder where the javadoc files are located
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: ${{env.prefix}}/stryker # The folder that we serve our javadoc files from
+          action: JamesIves/github-pages-deploy-action@v4
+          attempt_limit: 3
+          attempt_delay: 5000
+          with: |
+            branch: gh-pages # The branch the action should deploy to.
+            folder: frontend/reports/mutation # The folder where the javadoc files are located
+            clean: true # Automatically remove deleted files from the deploy branch
+            target-folder: ${{env.prefix}}/stryker # The folder that we serve our javadoc files from

--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -56,11 +56,15 @@ jobs:
           name: stryker-report
           path: frontend/reports/mutation/*
   
-      - name: Deploy 🚀
+      - name: Deploy 🚀    
         if: always() # always upload artifacts, even if tests fail
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: Wandalen/wretry.action@master
         with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: frontend/reports/mutation # The folder where the javadoc files are located
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: stryker # The folder that we serve our javadoc files from
+          action: JamesIves/github-pages-deploy-action@v4
+          attempt_limit: 3
+          attempt_delay: 5000
+          with: |
+            branch: gh-pages # The branch the action should deploy to.
+            folder: frontend/reports/mutation # The folder where the javadoc files are located
+            clean: true # Automatically remove deleted files from the deploy branch
+            target-folder: stryker # The folder that we serve our javadoc files from

--- a/.github/workflows/55-chromatic-pr.yml
+++ b/.github/workflows/55-chromatic-pr.yml
@@ -95,13 +95,18 @@ jobs:
           mkdir -p chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}
           echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.storybookUrl}}>" > chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}/index.html
           echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.url}}>" > chromatic_static_${{ needs.get-pr-num.outputs.pr_number }}/build.html
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: frontend/chromatic_static_${{ needs.get-pr-num.outputs.pr_number }} # The folder that the build-chromatic script generates files.
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/chromatic # The folder that we serve our chromatic files from 
-  
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: frontend/chromatic_static_${{ needs.get-pr-num.outputs.pr_number }} # The folder that the build-chromatic script generates files.
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/chromatic # The folder that we serve our chromatic files from 
+    
   
  

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -32,12 +32,17 @@ jobs:
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc
 
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/site/apidocs # The folder where the javadoc files are located
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: javadoc # The folder that we serve our javadoc files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/site/apidocs # The folder where the javadoc files are located
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: javadoc # The folder that we serve our javadoc files from
 
   

--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -77,13 +77,18 @@ jobs:
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc
  
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/site/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/javadoc # The folder that we serve our javadoc files from 
-  
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/site/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/javadoc # The folder that we serve our javadoc files from 
+    
   
  


### PR DESCRIPTION

The action JamesIves/github-pages-deploy-action@v4 often fails because of contention for the gh-pages branch. In this PR, we wrap many of these calls in a call to the Wandalen/wretry.action@master action,

which will try multiple times before giving up.

The intention is that fewer CI/CD jobs will fail at this step; today those jobs have to be re-run, which takes up extra developer time.

