### PR TITLE
Edit currentUser tests to kill OptionalChaining mutation

### DIFF
--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -223,28 +223,18 @@ describe("utils/currentUser tests", () => {
       expect(hasRole(currentUser, "ROLE_ADMIN")).toBeFalsy();
     });
 
-  test("hasRole falls back correctly with various data missing", async () => {
-    expect(hasRole(null, "ROLE_USER")).toBeFalsy();
-    expect(hasRole({}, "ROLE_USER")).toBeFalsy();
-    expect(hasRole({ data: null } , "ROLE_USER")).toBeFalsy();
-    expect(
-      hasRole({ data: { root: null } }, "ROLE_USER"),
-    ).toBeFalsy();
-    expect(
-      hasRole(
-        { data: { root: { rolesList: null } } },
-        "ROLE_USER",
-      ),
-    ).toBeFalsy();
-    expect(
-      hasRole(
-        { data: { root: { rolesList: [] } } },
-        "ROLE_USER",
-      ),
-    ).toBeFalsy();
-  });
-    expect(
-        hasRole({root: {rolesList: null}})
-    ).toBeFalsy();
+    test("hasRole falls back correctly with various data missing", async () => {
+      expect(hasRole(null, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({}, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: null }, "ROLE_USER")).toBeFalsy();
+      expect(hasRole({ data: { root: null } }, "ROLE_USER")).toBeFalsy();
+      expect(
+        hasRole({ data: { root: { rolesList: null } } }, "ROLE_USER"),
+      ).toBeFalsy();
+      expect(
+        hasRole({ data: { root: { rolesList: [] } } }, "ROLE_USER"),
+      ).toBeFalsy();
+    });
+    expect(hasRole({ root: { rolesList: null } })).toBeFalsy();
   });
 });

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -223,26 +223,28 @@ describe("utils/currentUser tests", () => {
       expect(hasRole(currentUser, "ROLE_ADMIN")).toBeFalsy();
     });
 
-    test("hasRole falls back correctly with various data missing", async () => {
-      expect(hasRole(null, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({}, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ currentUser: null }, "ROLE_USER")).toBeFalsy();
-      expect(hasRole({ currentUser: { data: null } }, "ROLE_USER")).toBeFalsy();
-      expect(
-        hasRole({ currentUser: { data: { root: null } } }, "ROLE_USER"),
-      ).toBeFalsy();
-      expect(
-        hasRole(
-          { currentUser: { data: { root: { rolesList: null } } } },
-          "ROLE_USER",
-        ),
-      ).toBeFalsy();
-      expect(
-        hasRole(
-          { currentUser: { data: { root: { rolesList: [] } } } },
-          "ROLE_USER",
-        ),
-      ).toBeFalsy();
-    });
+  test("hasRole falls back correctly with various data missing", async () => {
+    expect(hasRole(null, "ROLE_USER")).toBeFalsy();
+    expect(hasRole({}, "ROLE_USER")).toBeFalsy();
+    expect(hasRole({ data: null } , "ROLE_USER")).toBeFalsy();
+    expect(
+      hasRole({ data: { root: null } }, "ROLE_USER"),
+    ).toBeFalsy();
+    expect(
+      hasRole(
+        { data: { root: { rolesList: null } } },
+        "ROLE_USER",
+      ),
+    ).toBeFalsy();
+    expect(
+      hasRole(
+        { data: { root: { rolesList: [] } } },
+        "ROLE_USER",
+      ),
+    ).toBeFalsy();
+  });
+    expect(
+        hasRole({root: {rolesList: null}})
+    ).toBeFalsy();
   });
 });


### PR DESCRIPTION
This PR modifies the currentUser tests for the hasRole function to fix a failing OptionalChaining mutation test on main. The revised test checks the current user's roles in the tests from data.root instead of currentUser.data.root hierarchy. 

This fixes the failing mutation and tested locally for 100% Stryker mutation coverage.