### PR TITLE
Modify system info service to include git commit information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -343,6 +343,25 @@
           <timestampedReports>false</timestampedReports>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>8.0.2</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+          <commitIdGenerationMode>full</commitIdGenerationMode>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/edu/ucsb/cs156/rec/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/rec/models/SystemInfo.java
@@ -20,4 +20,8 @@ public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
   private String oauthLogin;
+  private String sourceRepo; // user configured URL of the source repository for footer
+  private String commitMessage;
+  private String commitId;
+  private String githubUrl; // URL to the commit in the source repository
 }

--- a/src/main/java/edu/ucsb/cs156/rec/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/rec/services/SystemInfoServiceImpl.java
@@ -1,6 +1,5 @@
 package edu.ucsb.cs156.rec.services;
 
-
 import edu.ucsb.cs156.rec.models.SystemInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,6 +27,20 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.oauth.login:/oauth2/authorization/google}")
   private String oauthLogin;
 
+  @Value("${app.sourceRepo:https://github.com/ucsb-cs156/proj-courses}")
+  private String sourceRepo;
+
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
+
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
+
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
+
+
   /**
    * This method returns the system information.
    * @see edu.ucsb.cs156.rec.models.SystemInfo
@@ -35,12 +48,16 @@ public class SystemInfoServiceImpl extends SystemInfoService {
    */
   public SystemInfo getSystemInfo() {
     SystemInfo si = SystemInfo.builder()
-    .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
-    .showSwaggerUILink(this.showSwaggerUILink)
-    .oauthLogin(this.oauthLogin)
-    .build();
-  log.info("getSystemInfo returns {}",si);
-  return si;
+        .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
+        .showSwaggerUILink(this.showSwaggerUILink)
+        .oauthLogin(this.oauthLogin)
+        .sourceRepo(this.sourceRepo)
+        .commitMessage(this.commitMessage)
+        .commitId(this.commitId)
+        .githubUrl(githubUrl(this.sourceRepo, this.commitId))
+        .build();
+    log.info("getSystemInfo returns {}", si);
+    return si;
   }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,7 @@ springdoc.swagger-ui.csrf.enabled=true
 management.endpoints.web.exposure.include=mappings
 
 app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
+app.sourceRepo=${SOURCE_REPO:${env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-rec}}
 
 spring.mvc.pathmatch.matching-strategy = ANT_PATH_MATCHER
 server.compression.enabled=false

--- a/src/test/java/edu/ucsb/cs156/rec/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/services/SystemInfoServiceImplTests.java
@@ -1,13 +1,11 @@
 package edu.ucsb.cs156.rec.services;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.test.context.TestPropertySource;
@@ -32,6 +30,20 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
+  }
+
+  @Test
+  void test_githubUrl() {
+    assertEquals(
+        SystemInfoServiceImpl.githubUrl(
+            "https://github.com/ucsb-cs156/proj-rec", "abcdef12345"),
+        "https://github.com/ucsb-cs156/proj-rec/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
   }
 
 }


### PR DESCRIPTION
In this PR, we modify the system info endpoint of the rec project to fetch and display the recent commit info from Github. 

This PR is based on this STARTER-team01 repo PR: https://github.com/ucsb-cs156-s25/STARTER-team01/pull/1, that adds the Git commit info to /api/systemInfo.