### PR TITLE
pc - fix broken git information in /api/systemInfo

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/rec/services/SystemInfoServiceImpl.java
@@ -4,6 +4,8 @@ import edu.ucsb.cs156.rec.models.SystemInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.stereotype.Service;
 
 /**
@@ -16,6 +18,9 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service("systemInfo")
 @ConfigurationProperties
+@PropertySources(
+  @PropertySource("classpath:git.properties")
+)
 public class SystemInfoServiceImpl extends SystemInfoService {
   
   @Value("${spring.h2.console.enabled:false}")


### PR DESCRIPTION
In this PR, we fix a bug that was causing /api/systemInfo to not properly display the commit information.

Before:

<img width="602" alt="image" src="https://github.com/user-attachments/assets/63e28e65-32ad-4fce-93fe-98c3deb6db27" />


After: 

<img width="551" alt="image" src="https://github.com/user-attachments/assets/fc0126f4-d591-447b-81b6-1c4ed811f23a" />

## Dokku (and test plan)

Compare output of: https://rec.dokku-00.cs.ucsb.edu/api/systemInfo which shows the before:

<img width="591" alt="image" src="https://github.com/user-attachments/assets/666a3601-b3b4-4661-b0c1-78d60708abbb" />

With output of: https://rec-qa.dokku-00.cs.ucsb.edu/api/systemInfo

<img width="607" alt="image" src="https://github.com/user-attachments/assets/fa28cdcb-1a1f-4a2a-8222-c74911cd02d0" />


## Explanation:

The service that pulls this information did not have the annotation to pull properties from git.properties. Now it does.

