### PR TITLE
React Router v7 Bump

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -5,7 +5,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { initialize, mswLoader } from 'msw-storybook-addon'
 
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { ToastContainer } from "react-toastify";
 
 const queryClient = new QueryClient();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "react-hook-form": "^7.53.0",
         "react-inspector": "^6.0.2",
         "react-query": "^3.39.3",
-        "react-router-dom": "^6.26.1",
+        "react-router": "^7.8.0",
         "react-scripts": "5.0.1",
         "react-table": "^7.8.0",
         "react-toastify": "^10.0.5",
@@ -5260,13 +5260,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.19.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@restart/hooks": {
@@ -20364,31 +20357,34 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.26.1",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
+      "integrity": "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.19.1"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/react-router-dom": {
-      "version": "6.26.1",
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.19.1",
-        "react-router": "6.26.1"
-      },
       "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "node": ">=18"
       }
     },
     "node_modules/react-scripts": {
@@ -21314,6 +21310,12 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "=v20.17.0"
+    "node": "^22.18.0"
   },
   "dependencies": {
     "@jest/core": "^29.7.0",
@@ -17,7 +17,7 @@
     "react-hook-form": "^7.53.0",
     "react-inspector": "^6.0.2",
     "react-query": "^3.39.3",
-    "react-router-dom": "^6.26.1",
+    "react-router": "^7.8.0",
     "react-scripts": "5.0.1",
     "react-table": "^7.8.0",
     "react-toastify": "^10.0.5",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router";
 import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -1,5 +1,5 @@
 import { Button, Container, Nav, Navbar, NavDropdown } from "react-bootstrap";
-import { Link } from "react-router-dom";
+import { Link } from "react-router";
 import { hasRole } from "main/utils/currentUser";
 import AppNavbarLocalhost from "main/components/Nav/AppNavbarLocalhost";
 

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.js
@@ -1,7 +1,7 @@
 import { Button, Form, Row, Col } from "react-bootstrap";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 function RecommendationRequestForm({
   initialContents,

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -12,7 +12,7 @@ import {
   cellToAxiosParamsUpdateStatus,
   onUpdateStatusSuccess,
 } from "main/utils/RecommendationRequestUtils";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router";
 import { hasRole } from "main/utils/currentUser";
 
 export default function RecommendationRequestTable({ requests, currentUser }) {

--- a/frontend/src/main/components/RequestType/RequestTypeForm.js
+++ b/frontend/src/main/components/RequestType/RequestTypeForm.js
@@ -1,6 +1,6 @@
 import { Button, Form, Row, Col } from "react-bootstrap";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 function RequestTypeForm({
   initialContents,

--- a/frontend/src/main/components/RequestType/RequestTypeTable.js
+++ b/frontend/src/main/components/RequestType/RequestTypeTable.js
@@ -6,7 +6,7 @@ import {
   cellToAxiosParamsDelete,
   onDeleteSuccess,
 } from "main/utils/RequestTypeUtils";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { hasRole } from "main/utils/currentUser";
 
 export default function RequestTypeTable({ requestTypes, currentUser }) {

--- a/frontend/src/main/pages/RequestType/RequestTypeCreatePage.js
+++ b/frontend/src/main/pages/RequestType/RequestTypeCreatePage.js
@@ -1,6 +1,6 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import RequestTypeForm from "main/components/RequestType/RequestTypeForm";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 

--- a/frontend/src/main/pages/RequestType/RequestTypeEditPage.js
+++ b/frontend/src/main/pages/RequestType/RequestTypeEditPage.js
@@ -1,7 +1,7 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import RequestTypeForm from "main/components/RequestType/RequestTypeForm";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 

--- a/frontend/src/main/pages/Requests/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/Requests/RecommendationRequestCreatePage.js
@@ -1,6 +1,6 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 

--- a/frontend/src/main/pages/Requests/RecommendationRequestEditPage.js
+++ b/frontend/src/main/pages/Requests/RecommendationRequestEditPage.js
@@ -1,7 +1,7 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { useParams } from "react-router-dom";
+import { useParams } from "react-router";
 import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
-import { Navigate } from "react-router-dom";
+import { Navigate } from "react-router";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 

--- a/frontend/src/main/pages/StudentProfilePage.js
+++ b/frontend/src/main/pages/StudentProfilePage.js
@@ -1,5 +1,5 @@
 import { Row, Col, Button } from "react-bootstrap";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { useCurrentUser } from "main/utils/currentUser";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";

--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import axios from "axios";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 export function useCurrentUser() {
   let rolesList = ["ERROR_GETTING_ROLES"];

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -3,3 +3,15 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+
+import { TextEncoder, TextDecoder } from "util"; // For Node.js built-in utility module
+
+// Polyfill TextEncoder if it's not already defined
+if (typeof global.TextEncoder === "undefined") {
+  global.TextEncoder = TextEncoder;
+}
+
+// Polyfill TextDecoder if it's not already defined
+if (typeof global.TextDecoder === "undefined") {
+  global.TextDecoder = TextDecoder;
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 
 import AppNavbar from "main/components/Nav/AppNavbar";

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router";
 
 import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
 import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
@@ -13,8 +13,8 @@ import recommendationTypeFixtures from "fixtures/recommendationTypeFixtures";
 
 const mockedNavigate = jest.fn();
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: () => mockedNavigate,
 }));
 

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { MemoryRouter, Routes, Route } from "react-router";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
@@ -12,8 +12,8 @@ import { toast } from "react-toastify";
 const mockedNavigate = jest.fn();
 let mockedLocation = { pathname: "" };
 
-jest.mock("react-router-dom", () => {
-  const actual = jest.requireActual("react-router-dom");
+jest.mock("react-router", () => {
+  const actual = jest.requireActual("react-router");
   return {
     ...actual,
     useNavigate: () => mockedNavigate,

--- a/frontend/src/tests/components/RequestType/RequestTypeForm.test.js
+++ b/frontend/src/tests/components/RequestType/RequestTypeForm.test.js
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
+import { BrowserRouter as Router } from "react-router";
 import { QueryClient, QueryClientProvider } from "react-query";
 
 import RequestTypeForm from "main/components/RequestType/RequestTypeForm";
@@ -7,8 +7,8 @@ import requestTypeFixtures from "fixtures/requestTypeFixtures";
 
 const mockedNavigate = jest.fn();
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: () => mockedNavigate,
 }));
 

--- a/frontend/src/tests/components/RequestType/RequestTypeTable.test.js
+++ b/frontend/src/tests/components/RequestType/RequestTypeTable.test.js
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { requestFixtures } from "fixtures/requestFixtures";
 import RequestTypeTable from "main/components/RequestType/RequestTypeTable";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
@@ -10,8 +10,8 @@ import { hasRole } from "main/utils/currentUser";
 
 const mockedNavigate = jest.fn();
 
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: () => mockedNavigate,
 }));
 

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -2,7 +2,7 @@ import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
 import UsersTable from "main/components/Users/UsersTable";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 

--- a/frontend/src/tests/pages/AdminRequestsPage.test.js
+++ b/frontend/src/tests/pages/AdminRequestsPage.test.js
@@ -1,6 +1,6 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";

--- a/frontend/src/tests/pages/AdminUsersPage.test.js
+++ b/frontend/src/tests/pages/AdminUsersPage.test.js
@@ -1,6 +1,6 @@
 import { render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import usersFixtures from "fixtures/usersFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import HomePage from "main/pages/HomePage";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";

--- a/frontend/src/tests/pages/ProfilePage.test.js
+++ b/frontend/src/tests/pages/ProfilePage.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 
 import axios from "axios";

--- a/frontend/src/tests/pages/RequestType/RequestTypeCreatePage.test.js
+++ b/frontend/src/tests/pages/RequestType/RequestTypeCreatePage.test.js
@@ -1,7 +1,7 @@
 import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import RequestTypeCreatePage from "main/pages/RequestType/RequestTypeCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -19,8 +19,8 @@ jest.mock("react-toastify", () => {
 });
 
 const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => {
-  const originalModule = jest.requireActual("react-router-dom");
+jest.mock("react-router", () => {
+  const originalModule = jest.requireActual("react-router");
   return {
     __esModule: true,
     ...originalModule,

--- a/frontend/src/tests/pages/RequestType/RequestTypeEditPage.test.js
+++ b/frontend/src/tests/pages/RequestType/RequestTypeEditPage.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import RequestTypeEditPage from "main/pages/RequestType/RequestTypeEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
@@ -21,8 +21,8 @@ jest.mock("react-toastify", () => {
 });
 
 const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => {
-  const originalModule = jest.requireActual("react-router-dom");
+jest.mock("react-router", () => {
+  const originalModule = jest.requireActual("react-router");
   return {
     __esModule: true,
     ...originalModule,

--- a/frontend/src/tests/pages/RequestType/RequestTypeIndexPage.test.js
+++ b/frontend/src/tests/pages/RequestType/RequestTypeIndexPage.test.js
@@ -1,7 +1,7 @@
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import RequestTypeIndexPage from "main/pages/RequestType/RequestTypeIndexPage";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import mockConsole from "jest-mock-console";
 import { requestFixtures } from "fixtures/requestFixtures";
 

--- a/frontend/src/tests/pages/Requests/CompletedRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/CompletedRequestsPage.test.js
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import CompletedRequestsPage from "main/pages/Requests/CompletedRequestsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";

--- a/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
+++ b/frontend/src/tests/pages/Requests/PendingRequestsPage.test.js
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import PendingRequestsPage from "main/pages/Requests/PendingRequestsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";

--- a/frontend/src/tests/pages/Requests/RecommendationRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/Requests/RecommendationRequestCreatePage.test.js
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import RecommendationRequestCreatePage from "main/pages/Requests/RecommendationRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
@@ -22,8 +22,8 @@ jest.mock("react-toastify", () => {
 });
 
 const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => {
-  const originalModule = jest.requireActual("react-router-dom");
+jest.mock("react-router", () => {
+  const originalModule = jest.requireActual("react-router");
   return {
     __esModule: true,
     ...originalModule,

--- a/frontend/src/tests/pages/Requests/RecommendationRequestEditPage.test.js
+++ b/frontend/src/tests/pages/Requests/RecommendationRequestEditPage.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import RecommendationRequestEditPage from "main/pages/Requests/RecommendationRequestEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
@@ -22,8 +22,8 @@ jest.mock("react-toastify", () => {
 });
 
 const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => {
-  const originalModule = jest.requireActual("react-router-dom");
+jest.mock("react-router", () => {
+  const originalModule = jest.requireActual("react-router");
   return {
     __esModule: true,
     ...originalModule,

--- a/frontend/src/tests/pages/Requests/StatisticsPage.test.js
+++ b/frontend/src/tests/pages/Requests/StatisticsPage.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import StatisticsPage from "main/pages/Requests/StatisticsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";

--- a/frontend/src/tests/pages/StudentProfilePage.test.js
+++ b/frontend/src/tests/pages/StudentProfilePage.test.js
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter, useNavigate } from "react-router-dom";
+import { MemoryRouter, useNavigate } from "react-router";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 
 import axios from "axios";
@@ -28,8 +28,8 @@ jest.mock("main/layouts/BasicLayout/BasicLayout", () => {
 });
 
 // Mock useNavigate
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
   useNavigate: jest.fn(),
 }));
 

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -6,14 +6,14 @@ import {
   currentUserFixtures,
 } from "fixtures/currentUserFixtures";
 import mockConsole from "jest-mock-console";
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-jest.mock("react-router-dom");
-const { MemoryRouter } = jest.requireActual("react-router-dom");
+jest.mock("react-router");
+const { MemoryRouter } = jest.requireActual("react-router");
 
 describe("utils/currentUser tests", () => {
   describe("useCurrentUser tests", () => {

--- a/frontend/src/tests/utils/systemInfo.test.js
+++ b/frontend/src/tests/utils/systemInfo.test.js
@@ -9,8 +9,8 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
-jest.mock("react-router-dom");
-const { _MemoryRouter } = jest.requireActual("react-router-dom");
+jest.mock("react-router");
+const { _MemoryRouter } = jest.requireActual("react-router");
 
 describe("utils/systemInfo tests", () => {
   describe("useSystemInfo tests", () => {

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -5,7 +5,7 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 
-jest.mock("react-router-dom");
+jest.mock("react-router");
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {


### PR DESCRIPTION
In this PR, I bump the version of react-router to react-router v7.

This requires that every `react-router-dom` import be replaced with `react-router`.

Additionally, I add the required polyfill changes for Node.js 22.18.0, which the version has been updated to.